### PR TITLE
Add conf unset + testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,17 +8,19 @@ on:
   # allow running manually
   workflow_dispatch:
 
+env:
+  SNAPCRAFT_BUILD_ENVIRONMENT: lxd
+  
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
 
-    # this will install and run snapcraft internally
-    - uses: snapcore/action-build@v1
-      # with:
-      #   snapcraft-args: prime
-      #   build-info: false
+    - name: Install Snapcraft with LXD
+      uses: samuelmeuli/action-snapcraft@v1
+      with:
+        use_lxd: true
 
-    # - name: Unit Tests
-    #   run: snapcraft prime unit-tests
+    - name: Unit Tests
+      run: snapcraft prime unit-tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,8 +20,13 @@ jobs:
     - name: Install Snapcraft with LXD
       run: |
         sudo snap install snapcraft --classic
-        sudo snap install lxd
-        sudo lxd init --auto
+    #     sudo snap install lxd
+    #     sudo lxd init --auto
+
+    - name: Setup LXD
+      uses: whywaita/setup-lxd@v1
+      with:
+        lxd_version: latest/stable
 
     - name: Unit Tests
       run: snapcraft prime unit-tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,8 @@
 name: Test
 
 on:
-  push:
-    branches: [ master ]
+  # push:
+  #   branches: [ master ]
   pull_request:
     branches: [ master ]
 
@@ -13,5 +13,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Unit Tests
-      run: snapcraft prime unit-tests
+    # this will install and run snapcraft internally
+    - uses: snapcore/action-build@v1
+      # with:
+      #   snapcraft-args: prime
+      #   build-info: false
+
+    # - name: Unit Tests
+    #   run: snapcraft prime unit-tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,15 +13,13 @@ env:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
 
-    - name: Install Snapcraft with LXD
+    - name: Install Snapcraft
       run: |
         sudo snap install snapcraft --classic
-    #     sudo snap install lxd
-    #     sudo lxd init --auto
 
     - name: Setup LXD
       uses: whywaita/setup-lxd@v1
@@ -29,4 +27,4 @@ jobs:
         lxd_version: latest/stable
 
     - name: Unit Tests
-      run: snapcraft prime unit-tests
+      run: snapcraft build unit-tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,17 @@
+name: Test
+
+on:
+#   push:
+#     branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Unit Tests
+      run: snapcraft prime unit-tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   SNAPCRAFT_BUILD_ENVIRONMENT: lxd
-  
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -18,9 +18,10 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Install Snapcraft with LXD
-      uses: samuelmeuli/action-snapcraft@v1
-      with:
-        use_lxd: true
+      run: |
+        sudo snap install snapcraft --classic
+        sudo snap install lxd
+        sudo lxd init --auto
 
     - name: Unit Tests
       run: snapcraft prime unit-tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,8 @@
 name: Test
 
 on:
-#   push:
-#     branches: [ master ]
+  push:
+    branches: [ master ]
   pull_request:
     branches: [ master ]
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,5 @@
 .PHONY: test
 
-GO=CGO_ENABLED=1 GO111MODULE=on go
-
 test:
-	$(GO) test ./... -coverprofile=coverage.out ./...
-	$(GO) vet ./...
+	go test -v ./... --cover
+	go vet ./...

--- a/README.md
+++ b/README.md
@@ -14,3 +14,11 @@ This module provides support for Go-based configure an install hooks...
 
 ### How to Use ###
 
+TBA
+
+### Testing
+The tests need to run in a snap environment:
+
+```bash
+snapcraft prime
+```

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,17 @@
+name: edgex-snap-hooks
+base: core20
+version: test
+summary: EdgeX Snap Hooks package tester
+description: This snap is used to run tests on this package
+
+grade: devel
+confinement: strict
+
+parts:
+  unit-tests:
+    source: .
+    plugin: go
+    go-channel: 1.16/stable
+    override-build: |
+      make test
+

--- a/utils.go
+++ b/utils.go
@@ -61,6 +61,7 @@ type CtlCli struct{}
 type SnapCtl interface {
 	Config(key string) (string, error)
 	SetConfig(key string, val string) error
+	UnsetConfig(key string) error
 	Stop(svc string, disable bool) error
 }
 
@@ -214,6 +215,16 @@ func (cc *CtlCli) SetConfig(key string, val string) error {
 	err := exec.Command("snapctl", "set", fmt.Sprintf("%s=%s", key, val)).Run()
 	if err != nil {
 		return fmt.Errorf("snapctl SET failed for %s - %v", key, err)
+	}
+	return nil
+}
+
+// UnsetConfig uses snapctl to unset a config value from a key
+func (cc *CtlCli) UnsetConfig(key string) error {
+
+	err := exec.Command("snapctl", "unset", key).Run()
+	if err != nil {
+		return fmt.Errorf("snapctl UNSET failed for %s - %v", key, err)
 	}
 	return nil
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -20,9 +20,12 @@ package hooks
 
 import (
 	"os"
+	"os/exec"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TODO: add more tests (see trello: )
@@ -65,8 +68,8 @@ func TestGetConfigEnvVar(t *testing.T) {
 
 	// test extra key
 	var extraConf = map[string]string{
-		"service.mykey":     "SERVICE_MYKEY",
-		"service.mykey-2":   "SERVICE_MYKEY2",
+		"service.mykey":   "SERVICE_MYKEY",
+		"service.mykey-2": "SERVICE_MYKEY2",
 	}
 
 	// extra key exists
@@ -82,4 +85,23 @@ func TestGetConfigEnvVar(t *testing.T) {
 	// extra key doesn't exist
 	env, ok = getConfigEnvVar("service.fubar", extraConf)
 	assert.False(t, ok)
+}
+
+func TestSetConfig(t *testing.T) {
+	key, value := "mykey", "myvalue"
+
+	cli := NewSnapCtl()
+	err := cli.SetConfig(key, value)
+	require.Nilf(t, err, "Error setting config.", err)
+
+	// check using snapctl
+	require.Equal(t, value, getConfigValue(t, key))
+}
+
+// utility testing functions
+
+func getConfigValue(t *testing.T, key string) string {
+	out, err := exec.Command("snapctl", "get", key).Output()
+	require.Nilf(t, err, "Error getting config value via snapctl.")
+	return strings.TrimSpace(string(out))
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -19,6 +19,7 @@
 package hooks
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"strings"
@@ -98,7 +99,33 @@ func TestSetConfig(t *testing.T) {
 	require.Equal(t, value, getConfigValue(t, key))
 }
 
+func TestUnsetConfig(t *testing.T) {
+	key, value := "mykey2", "myvalue"
+
+	// make sure this isn't already set
+	require.Equal(t, "", getConfigValue(t, key))
+
+	// set using snapctl
+	setConfigValue(t, key, value)
+
+	// check using snapctl
+	require.Equal(t, value, getConfigValue(t, key))
+
+	// set using the library
+	cli := NewSnapCtl()
+	err := cli.UnsetConfig(key)
+	require.Nilf(t, err, "Error un-setting config.", err)
+
+	// make sure it has been unset
+	require.Equal(t, "", getConfigValue(t, key))
+}
+
 // utility testing functions
+
+func setConfigValue(t *testing.T, key, value string) {
+	err := exec.Command("snapctl", "set", fmt.Sprintf("%s=%s", key, value)).Run()
+	require.Nilf(t, err, "Error setting config value via snapctl.")
+}
 
 func getConfigValue(t *testing.T, key string) string {
 	out, err := exec.Command("snapctl", "get", key).Output()


### PR DESCRIPTION
This adds an UnsetConfig function together with some testing.

Testing is performed as part of the snap build. It may be necessary to do it in another stage or as a one-shot service depending on how unit tests progress.

To run the tests locally:
```bash
snapcraft prime unit-tests
```
or just:
```bash
snapcraft prime unit-tests
```
since there is only one part right now.

The added CI workflow uses snapcore's [action-build](https://github.com/snapcore/action-build) to install snapcraft. Unfortunately, that runs a whole `snapcraft` right now and checks that a snap is produces. The installation itself takes 1.5 minutes. Alternatively, we can:
- file a feature request to allow build without expecting a produced snap
- install and configure snapcraft from scratch
- find another github action that is suitable for testing (e.g. https://github.com/marketplace/actions/snapcraft-action)

The action doesn't run under this PR perhaps because the repo doesn't have Github actions yet. But it runs fine against my master (see the checks under the PR): https://github.com/farshidtz/edgex-snap-hooks/pull/1

 