### PR TITLE
Snapped testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,12 +8,22 @@ on:
   # allow running manually
   workflow_dispatch:
 
+env:
+  SNAPCRAFT_BUILD_ENVIRONMENT: lxd
+
 jobs:
-  build:
-    runs-on: ubuntu-latest
-
+  test:
+    runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+    - uses: actions/checkout@v2
 
-      - name: Run a one-line script
-        run: echo "Nothing to test!"
+    - name: Install Snapcraft
+      run: |
+        sudo snap install snapcraft --classic
+    - name: Setup LXD
+      uses: whywaita/setup-lxd@v1
+      with:
+        lxd_version: latest/stable
+
+    - name: Unit Tests
+      run: snapcraft build unit-tests

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,5 @@
 .PHONY: test
 
-GO=CGO_ENABLED=1 GO111MODULE=on go
-
 test:
-	$(GO) test ./... -coverprofile=coverage.out ./...
-	$(GO) vet ./...
+	go test -v ./... --cover
+	go vet ./...

--- a/README.md
+++ b/README.md
@@ -14,3 +14,11 @@ This module provides support for Go-based configure an install hooks...
 
 ### How to Use ###
 
+TBA
+
+### Testing
+The tests need to run in a snap environment:
+
+```bash
+snapcraft prime
+```

--- a/README.md
+++ b/README.md
@@ -20,5 +20,5 @@ TBA
 The tests need to run in a snap environment:
 
 ```bash
-snapcraft prime
+snapcraft build
 ```

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,17 @@
+name: edgex-snap-hooks
+base: core20
+version: test
+summary: EdgeX Snap Hooks package tester
+description: This snap is used to run tests on this package
+
+grade: devel
+confinement: strict
+
+parts:
+  unit-tests:
+    source: .
+    plugin: go
+    go-channel: 1.16/stable
+    override-build: |
+      make test
+

--- a/utils_test.go
+++ b/utils_test.go
@@ -20,9 +20,12 @@ package hooks
 
 import (
 	"os"
+	"os/exec"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TODO: add more tests (see trello: )
@@ -65,8 +68,8 @@ func TestGetConfigEnvVar(t *testing.T) {
 
 	// test extra key
 	var extraConf = map[string]string{
-		"service.mykey":     "SERVICE_MYKEY",
-		"service.mykey-2":   "SERVICE_MYKEY2",
+		"service.mykey":   "SERVICE_MYKEY",
+		"service.mykey-2": "SERVICE_MYKEY2",
 	}
 
 	// extra key exists
@@ -82,4 +85,23 @@ func TestGetConfigEnvVar(t *testing.T) {
 	// extra key doesn't exist
 	env, ok = getConfigEnvVar("service.fubar", extraConf)
 	assert.False(t, ok)
+}
+
+func TestSetConfig(t *testing.T) {
+	key, value := "mykey", "myvalue"
+
+	cli := NewSnapCtl()
+	err := cli.SetConfig(key, value)
+	require.Nilf(t, err, "Error setting config.", err)
+
+	// check using snapctl
+	require.Equal(t, value, getConfigValue(t, key))
+}
+
+// utility testing functions
+
+func getConfigValue(t *testing.T, key string) string {
+	out, err := exec.Command("snapctl", "get", key).Output()
+	require.Nilf(t, err, "Error getting config value via snapctl.")
+	return strings.TrimSpace(string(out))
 }


### PR DESCRIPTION
This PR supersedes #14.

It adds a snap for running the unit tests locally or as a Github Action. Moreover, it adds a test for config set.

Testing is performed as part of the snap build. It may be necessary to do it in another stage or as a one-shot service depending on how unit tests progress.

To run the tests locally:
```bash
snapcraft build unit-tests
```

 