### PR TITLE
feat: add function to unset config value

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -61,6 +61,7 @@ type CtlCli struct{}
 type SnapCtl interface {
 	Config(key string) (string, error)
 	SetConfig(key string, val string) error
+	UnsetConfig(key string) error
 	Stop(svc string, disable bool) error
 }
 
@@ -214,6 +215,16 @@ func (cc *CtlCli) SetConfig(key string, val string) error {
 	err := exec.Command("snapctl", "set", fmt.Sprintf("%s=%s", key, val)).Run()
 	if err != nil {
 		return fmt.Errorf("snapctl SET failed for %s - %v", key, err)
+	}
+	return nil
+}
+
+// UnsetConfig uses snapctl to unset a config value from a key
+func (cc *CtlCli) UnsetConfig(key string) error {
+
+	err := exec.Command("snapctl", "unset", key).Run()
+	if err != nil {
+		return fmt.Errorf("snapctl UNSET failed for %s - %v", key, err)
 	}
 	return nil
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -19,6 +19,7 @@
 package hooks
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"strings"
@@ -98,7 +99,33 @@ func TestSetConfig(t *testing.T) {
 	require.Equal(t, value, getConfigValue(t, key))
 }
 
+func TestUnsetConfig(t *testing.T) {
+	key, value := "mykey2", "myvalue"
+
+	// make sure this isn't already set
+	require.Equal(t, "", getConfigValue(t, key))
+
+	// set using snapctl
+	setConfigValue(t, key, value)
+
+	// check using snapctl
+	require.Equal(t, value, getConfigValue(t, key))
+
+	// set using the library
+	cli := NewSnapCtl()
+	err := cli.UnsetConfig(key)
+	require.Nilf(t, err, "Error un-setting config.", err)
+
+	// make sure it has been unset
+	require.Equal(t, "", getConfigValue(t, key))
+}
+
 // utility testing functions
+
+func setConfigValue(t *testing.T, key, value string) {
+	err := exec.Command("snapctl", "set", fmt.Sprintf("%s=%s", key, value)).Run()
+	require.Nilf(t, err, "Error setting config value via snapctl.")
+}
 
 func getConfigValue(t *testing.T, key string) string {
 	out, err := exec.Command("snapctl", "get", key).Output()


### PR DESCRIPTION
This PR supersedes #14 

It adds a UnsetConfig function to unset a config value.

Current workaround from https://github.com/edgexfoundry/edgex-go/pull/3791:
Use [SetConfig](https://pkg.go.dev/github.com/canonical/edgex-snap-hooks#CtlCli.SetConfig) and set the config value to empty string.