### PR TITLE
fix(snap): add Kong Admin JWT to TLS requests

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -528,13 +528,18 @@ func securityProxySetTLSCertificate(tlsCertificate, tlsPrivateKey, tlsSNI string
 	if err != nil {
 		return err
 	}
-	if tlsSNI != "" {
-		args := []string{"proxy", "tls", "--incert", tlsCertFilename, "--inkey", tlsPrivateKeyFilename, "--snis", tlsSNI}
-		err = securityProxyExecSecretsConfig(args)
-	} else {
-		args := []string{"proxy", "tls", "--incert", tlsCertFilename, "--inkey", tlsPrivateKeyFilename}
-		err = securityProxyExecSecretsConfig(args)
+
+	kongAdminToken, err := securityProxyReadFile(kongAdminTokenFile)
+	if err != nil {
+		return err
 	}
+
+	args := []string{"proxy", "tls", "--incert", tlsCertFilename, "--inkey", tlsPrivateKeyFilename, "--admin_api_jwt", kongAdminToken}
+	if tlsSNI != "" {
+		args = append(args, "--snis", tlsSNI)
+	}
+	err = securityProxyExecSecretsConfig(args)
+
 	if err != nil {
 		return fmt.Errorf("failed to set TLS certificate - %v", err)
 	}


### PR DESCRIPTION
This commit fixes an issue with ` snap set edgexfoundry env.security-proxy.tls-certificate` and `snap set edgexfoundry env.security-proxy.tls-private-key`

Using those commands currently results in failure:  `error: cannot perform the following tasks:
Run configure hook of "edgexfoundry" snap (run hook "configure": exit status 1)`

Signed-off-by: Siggi Skulason <siggi.skulason@canonical.com>

## Test instructions:

Note: the instructions below are also in the Snap README.md and they are being updated in a pending PR (https://github.com/edgexfoundry/edgex-go/pull/3794 )

To test this you need to get the edgex-go source and then update `/snap/local/hooks/go.mod`, adding a `replace` line at the end:

```
replace github.com/canonical/edgex-snap-hooks/v2 v2.0.5 => github.com/siggiskulason/edgex-snap-hooks/v2 v2.1.0-1
```

so your go.mod file should look like

```
module github.com/canonical/edgex-go/hooks

require github.com/canonical/edgex-snap-hooks/v2 v2.0.5

go 1.16

replace github.com/canonical/edgex-snap-hooks/v2 v2.0.5 => github.com/siggiskulason/edgex-snap-hooks/v2 v2.1.0-1
```


Build and install the edgexfoundry snap. It will use the snap hooks from this branch. Then follow the following instructions.

 
1. Create a Kong user:

```
# Create private key:
openssl ecparam -genkey -name prime256v1 -noout -out private.pem

# Create public key:
openssl ec -in private.pem -pubout -out public.pem

# set user=username,user id,algorithm (ES256 or RS256)
sudo snap set edgexfoundry env.security-proxy.user=user01,USER_ID,ES256

# set public-key to the contents of a PEM-encoded public key file
sudo snap set edgexfoundry env.security-proxy.public-key="$(cat public.pem)"

# get token:
TOKEN=`edgexfoundry.secrets-config proxy jwt --algorithm ES256 --private_key private.pem --id USER_ID --expiration=1h`
```

2. You can then connect using the JWT token, but as the certificate is self-signed, you need the "-k" argument for curl:

```
curl -k -X GET https://localhost:8443/core-data/api/v2/ping? -H "Authorization: Bearer $TOKEN"
```

3. Now create a new TLS certificate, using the edgeca snap:

```
sudo snap install edgeca
edgeca gencsr --cn localhost --csr csrfile --key csrkeyfile
edgeca gencert -o localhost.cert -i csrfile -k localhost.key
```

4. and install the certificate:

```
sudo snap set edgexfoundry env.security-proxy.tls-certificate="$(cat localhost.cert)"
sudo snap set edgexfoundry env.security-proxy.tls-private-key="$(cat localhost.key)"
```

5. Try the new certificate

This sample certificate is signed by the EdgeCA root CA, so by specifying the Root CA certificate for validation then a connection can now be made using your new certificate, providing the path to the Root CA certificate instead of using the "-k" flag:

```
curl -v --cacert /var/snap/edgeca/current/CA.pem -X GET https://localhost:8443/core-data/api/v2/ping? -H "Authorization: Bearer $TOKEN"
```

Note that the verbose information shows that the issuer of this certificate is now

```
issuer: CN=EdgeCASubCA
```
which confirms that this new certificate is the one you just generated



