### PR TITLE
Replace with original Apache 2.0 license text

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2017 Dell, Inc.
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
This commit replaces the included license text with the original Apache 2.0 license from https://www.apache.org/licenses/LICENSE-2.0.txt

The included text specified "Dell, Inc." as copyright holder in the appendix. This was simply due to a replication error as the license was taken from another project.