### PR TITLE
Return snapctl standard errors to caller

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -204,29 +204,27 @@ func NewSnapCtl() *CtlCli {
 
 // Config uses snapctl to get a value from a key, or returns error.
 func (cc *CtlCli) Config(key string) (string, error) {
-	out, err := exec.Command("snapctl", "get", key).Output()
+	output, err := exec.Command("snapctl", "get", key).CombinedOutput()
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("snapctl get failed for %s: %s: %s", key, err, output)
 	}
-	return strings.TrimSpace(string(out)), nil
+	return strings.TrimSpace(string(output)), nil
 }
 
 // SetConfig uses snapctl to set a config value from a key, or returns error.
 func (cc *CtlCli) SetConfig(key string, val string) error {
-
-	err := exec.Command("snapctl", "set", fmt.Sprintf("%s=%s", key, val)).Run()
+	output, err := exec.Command("snapctl", "set", fmt.Sprintf("%s=%s", key, val)).CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("snapctl SET failed for %s - %v", key, err)
+		return fmt.Errorf("snapctl set failed for %s: %s: %s", key, err, output)
 	}
 	return nil
 }
 
 // UnsetConfig uses snapctl to unset a config value from a key
 func (cc *CtlCli) UnsetConfig(key string) error {
-
-	err := exec.Command("snapctl", "unset", key).Run()
+	output, err := exec.Command("snapctl", "unset", key).CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("snapctl UNSET failed for %s - %v", key, err)
+		return fmt.Errorf("snapctl unset failed for %s: %s: %s", key, err, output)
 	}
 	return nil
 }
@@ -242,9 +240,9 @@ func (cc *CtlCli) Start(svc string, enable bool) error {
 		cmd = exec.Command("snapctl", "start", name)
 	}
 
-	err := cmd.Run()
+	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("snapctl start %s failed - %v", name, err)
+		return fmt.Errorf("snapctl start %s failed: %s: %s", name, err, output)
 	}
 
 	return nil
@@ -266,11 +264,9 @@ func (cc *CtlCli) StartMultiple(enable bool, services ...string) error {
 		args = append(args, SnapName+"."+s)
 	}
 
-	cmd := exec.Command("snapctl", args...)
-
-	std, err := cmd.CombinedOutput()
+	output, err := exec.Command("snapctl", args...).CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("snapctl start failed: %s: %s", err, std)
+		return fmt.Errorf("snapctl start failed: %s: %s", err, output)
 	}
 
 	return nil
@@ -287,9 +283,9 @@ func (cc *CtlCli) Stop(svc string, disable bool) error {
 		cmd = exec.Command("snapctl", "stop", name)
 	}
 
-	err := cmd.Run()
+	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("snapctl stop %s failed - %v", name, err)
+		return fmt.Errorf("snapctl stop %s failed: %s: %s", name, err, output)
 	}
 
 	return nil

--- a/utils.go
+++ b/utils.go
@@ -118,6 +118,7 @@ func Debug(msg string) {
 
 // Error writes the given msg to sylog (sev=LOG_ERROR).
 func Error(msg string) {
+	fmt.Fprintf(os.Stderr, msg)
 	log.Err(msg)
 }
 


### PR DESCRIPTION
Fixes #15 

### Current behaviour
Error message not printed to stderr.
```
$ sudo snap install edgexfoundry --edge
edgexfoundry (edge) 2.2.0-dev.20 from Canonical✓ installed
$ sudo snap set edgexfoundry env.security-proxy.user="bad-user"
error: cannot perform the following tasks:
- Run configure hook of "edgexfoundry" snap (run hook "configure": exit status 1)
$
$
$ journalctl -n 100 -o cat | grep "bad-user"
farshid : TTY=pts/3 ; PWD=/home/farshid ; USER=root ; COMMAND=/usr/bin/snap set edgexfoundry env.security-proxy.user=bad-user
edgexfoundry:configure: error handling services: security-proxy.user expects a value containing 'username,userID,algorithm'. Example: 'me,1234,ES256' but got [bad-user]
taskrunner.go:271: [change 16494 "Run configure hook of \"edgexfoundry\" snap" task] failed: run hook "configure": edgexfoundry:configure: error handling services: security-proxy.user expects a value containing 'username,userID,algorithm'. Example: 'me,1234,ES256' but got [bad-user]
```

### Test
1. checkout edgex-go and enter the directory:
```
git clone https://github.com/edgexfoundry/edgex-go.git
cd edgex-go
```
2. checkout this branch inside `snap/local/farshidtz/hooks` directory
```
git clone --branch=return-stderr https://github.com/farshidtz/edgex-snap-hooks.git snap/local/hooks/egex-snap-hooks-return-stderr
```
3. add `replace github.com/canonical/edgex-snap-hooks/v2 => ./egex-snap-hooks-return-stderr` to `snap/local/hooks/go.mod`
4. build
```
snapcraft clean
snapcraft
```
5. Install
6. Produce some errors
#### Function error
```
$ sudo snap set edgexfoundry env.security-proxy.user="bad-user"
error: cannot perform the following tasks:
- Run configure hook of "edgexfoundry" snap (run hook "configure": edgexfoundry:configure: error handling services: security-proxy.user expects a value containing 'username,userID,algorithm'. Example: 'me,1234,ES256' but got [bad-user])
```
#### Snapctl error
Reproducing https://github.com/edgexfoundry/edgex-go/issues/3863 to see if we now do get the error:
```
$ sudo rm -r /var/snap/edgexfoundry/current/secrets/security-proxy-setup
$
$ sudo snap set edgexfoundry env.security-proxy.user="me,1234,ES256" env.security-proxy.public-key="some text"
error: cannot perform the following tasks:
- Run configure hook of "edgexfoundry" snap (run hook "configure": edgexfoundry:configure: error handling services: failed to write file /var/snap/edgexfoundry/x3/secrets/security-proxy-setup/jwt-user-public-key.pem - open /var/snap/edgexfoundry/x3/secrets/security-proxy-setup/jwt-user-public-key.pem: no such file or directory)
```

All checkbox tests from the `latest` suite pass.