### PR TITLE
Create a separate log package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,4 +7,7 @@ sync:
 	cp -r $$(ls | egrep -v '^prime') prime/
 
 test:
-	sudo edgex-snap-hooks.test ./ ./snapctl ./log
+	sudo edgex-snap-hooks.test \
+		./ \
+		./log \
+		./snapctl

--- a/Makefile
+++ b/Makefile
@@ -7,4 +7,4 @@ sync:
 	cp -r $$(ls | egrep -v '^prime') prime/
 
 test:
-	sudo edgex-snap-hooks.test ./ ./snapctl
+	sudo edgex-snap-hooks.test ./ ./snapctl ./log

--- a/log/init.go
+++ b/log/init.go
@@ -13,17 +13,16 @@ var (
 )
 
 func init() {
-	debug = (os.Getenv("DEBUG") == "true")
-	// snap config option overrides environment variable
-	if !debug {
-		snapctl.Unset("debug").Run()
-		value, err := snapctl.Get("debug").Run()
-		if err != nil {
-			stderr(err)
-			os.Exit(1)
-		}
-		debug = (value == "true")
+	initialize()
+}
+
+func initialize() {
+	value, err := snapctl.Get("debug").Run()
+	if err != nil {
+		stderr(err)
+		os.Exit(1)
 	}
+	debug = (value == "true")
 
 	snapInstanceKey = os.Getenv("SNAP_INSTANCE_NAME")
 	if snapInstanceKey == "" {

--- a/log/init.go
+++ b/log/init.go
@@ -1,0 +1,39 @@
+package log
+
+import (
+	"os"
+
+	"github.com/canonical/edgex-snap-hooks/v2/snapctl"
+)
+
+var (
+	debug           bool
+	snapInstanceKey string // used as default syslog tag and tag prefix
+	tag             string // syslog tag and stderr prefix
+)
+
+func init() {
+	debug = (os.Getenv("DEBUG") == "true")
+	// snap config option overrides environment variable
+	if !debug {
+		snapctl.Unset("debug").Run()
+		value, err := snapctl.Get("debug").Run()
+		if err != nil {
+			stderr(err)
+			os.Exit(1)
+		}
+		debug = (value == "true")
+	}
+
+	snapInstanceKey = os.Getenv("SNAP_INSTANCE_NAME")
+	if snapInstanceKey == "" {
+		stderr("SNAP_INSTANCE_NAME environment variable not set.")
+		os.Exit(1)
+	}
+	tag = snapInstanceKey
+
+	if err := setupSyslogWriter(tag); err != nil {
+		stderr(err)
+		os.Exit(1)
+	}
+}

--- a/log/init_test.go
+++ b/log/init_test.go
@@ -26,7 +26,7 @@ import (
 
 func TestInitialize(t *testing.T) {
 
-	t.Run("debug", func(t *testing.T) {
+	t.Run("global debug value", func(t *testing.T) {
 		// should be false by default
 		require.False(t, debug)
 

--- a/log/init_test.go
+++ b/log/init_test.go
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0'
+ */
+
+package log
+
+import (
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInitialize(t *testing.T) {
+
+	t.Run("debug", func(t *testing.T) {
+		// should be false by default
+		require.False(t, debug)
+
+		// set it to true and check
+		output, err := exec.Command("snapctl", "set", "debug=true").CombinedOutput()
+		assert.NoError(t, err, "Error setting config value via snapctl: %s", output)
+		initialize()
+		require.True(t, debug)
+
+		// unset and re-check
+		output, err = exec.Command("snapctl", "unset", "debug").CombinedOutput()
+		assert.NoError(t, err, "Error setting config value via snapctl: %s", output)
+		initialize()
+		require.False(t, debug)
+	})
+
+	t.Run("global instance key", func(t *testing.T) {
+		require.NotEmpty(t, snapInstanceKey)
+	})
+
+	t.Run("global syslog writer", func(t *testing.T) {
+		require.NotNil(t, slog)
+	})
+}

--- a/log/log.go
+++ b/log/log.go
@@ -36,7 +36,7 @@ func init() {
 	if !debug {
 		snapctl.Unset("debug").Run()
 		if value, err := snapctl.Get("debug").Run(); err != nil {
-			fmt.Fprint(os.Stderr, err)
+			Stderr(err)
 			os.Exit(1)
 		} else {
 			debug = (value == "true")
@@ -45,12 +45,12 @@ func init() {
 
 	snapInstanceKey = os.Getenv("SNAP_INSTANCE_NAME")
 	if snapInstanceKey == "" {
-		fmt.Fprint(os.Stderr, "SNAP_INSTANCE_NAME environment variable not set.")
+		Stderr("SNAP_INSTANCE_NAME environment variable not set.")
 		os.Exit(1)
 	}
 
 	if err := setupSyslogWriter(snapInstanceKey); err != nil {
-		fmt.Fprint(os.Stderr, err)
+		Stderr(err)
 		os.Exit(1)
 	}
 
@@ -102,7 +102,7 @@ func Error(a ...interface{}) {
 	msg := fmt.Sprint(a...)
 	slog.Err(msg)
 	// print to stderr as well for snap command error output
-	fmt.Fprint(os.Stderr, msg)
+	Stderr(a...)
 }
 
 // Errorf writes the given input to syslog (sev=LOG_ERROR).
@@ -133,4 +133,16 @@ func Warn(a ...interface{}) {
 // It formats similar to fmt.Sprintf
 func Warnf(format string, a ...interface{}) {
 	Warn(fmt.Sprintf(format, a...))
+}
+
+// Stderr writes the given input to standard error.
+// It formats similar to fmt.Sprint
+func Stderr(a ...interface{}) {
+	fmt.Fprint(os.Stderr, a...)
+}
+
+// Stderrf writes the given input to standard error.
+// It formats similar to fmt.Sprintf
+func Stderrf(format string, a ...interface{}) {
+	fmt.Fprintf(os.Stderr, format, a...)
 }

--- a/log/log.go
+++ b/log/log.go
@@ -20,44 +20,9 @@ import (
 	"fmt"
 	"log/syslog"
 	"os"
-
-	"github.com/canonical/edgex-snap-hooks/v2/snapctl"
 )
 
-var (
-	slog            *syslog.Writer
-	debug           bool
-	snapInstanceKey string // used as default syslog tag and tag prefix
-	tag             string // syslog tag and stderr prefix
-)
-
-func init() {
-	debug = (os.Getenv("DEBUG") == "true")
-	// snap config option overrides environment variable
-	if !debug {
-		snapctl.Unset("debug").Run()
-		value, err := snapctl.Get("debug").Run()
-		if err != nil {
-			stderr(err)
-			os.Exit(1)
-		}
-		debug = (value == "true")
-	}
-
-	snapInstanceKey = os.Getenv("SNAP_INSTANCE_NAME")
-	if snapInstanceKey == "" {
-		stderr("SNAP_INSTANCE_NAME environment variable not set.")
-		os.Exit(1)
-	}
-	tag = snapInstanceKey
-
-	if err := setupSyslogWriter(tag); err != nil {
-		stderr(err)
-		os.Exit(1)
-	}
-
-	Debugf("debug=%t", debug)
-}
+var slog *syslog.Writer
 
 // SetComponentName adds a component name to syslog tag as "my-snap.<component>"
 // The default tag is just "my-snap", read from the snap environment.

--- a/log/log.go
+++ b/log/log.go
@@ -136,9 +136,9 @@ func Warnf(format string, a ...interface{}) {
 }
 
 // Stderr writes the given input to standard error.
-// It formats similar to fmt.Sprint
+// It formats similar to fmt.Sprintln
 func Stderr(a ...interface{}) {
-	fmt.Fprint(os.Stderr, a...)
+	fmt.Fprintln(os.Stderr, a...)
 }
 
 // Stderrf writes the given input to standard error.

--- a/log/log.go
+++ b/log/log.go
@@ -20,12 +20,47 @@ import (
 	"fmt"
 	"log/syslog"
 	"os"
+
+	"github.com/canonical/edgex-snap-hooks/v2/snapctl"
 )
 
 var (
-	slog  *syslog.Writer
-	debug bool = false
+	slog            *syslog.Writer
+	debug           bool
+	snapInstanceKey string // used as default syslog tag and tag prefix
 )
+
+func init() {
+	if value, err := snapctl.Get("debug").Run(); err != nil {
+		panic(err)
+	} else {
+		debug = (value == "true")
+	}
+
+	snapInstanceKey = os.Getenv("SNAP_INSTANCE_NAME")
+	if snapInstanceKey == "" {
+		panic("SNAP_INSTANCE_NAME environment variable not set.")
+	}
+
+	var err error
+	slog, err = syslog.New(syslog.LOG_INFO, snapInstanceKey)
+	if err != nil {
+		panic(err)
+	}
+}
+
+// SetComponentName adds a component name to syslog app name as "my-snap.<component>"
+// The default app name is just "my-snap", read from the snap environment.
+// This function is NOT thread-safe. It should not be called concurrently with
+// the other logging functions of this package.
+// Syslog app name: https://datatracker.ietf.org/doc/html/rfc5424#section-6.2.5
+func SetComponentName(component string) {
+	var err error
+	slog, err = syslog.New(syslog.LOG_INFO, snapInstanceKey+"."+component)
+	if err != nil {
+		panic(err)
+	}
+}
 
 // Debug writes the given input to syslog (sev=LOG_DEBUG) if snap `debug`
 // configuration option is set to `true`.
@@ -80,21 +115,4 @@ func Warn(a ...interface{}) {
 // It formats similar to fmt.Sprintf
 func Warnf(format string, a ...interface{}) {
 	Warn(fmt.Sprintf(format, a...))
-}
-
-func init() {
-	// TODO: use snapctl get debug to read this
-	// Depends on https://github.com/canonical/edgex-snap-hooks/pull/26
-	debug = true
-
-	snap := os.Getenv("SNAP")
-	if snap == "" {
-		panic("SNAP environment variable is not set")
-	}
-
-	var err error
-	slog, err = syslog.New(syslog.LOG_INFO, snap+":hook")
-	if err != nil {
-		panic(err)
-	}
 }

--- a/log/log.go
+++ b/log/log.go
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0'
+ */
+
+package log
+
+import (
+	"fmt"
+	"log/syslog"
+	"os"
+)
+
+var (
+	slog  *syslog.Writer
+	debug bool = false
+)
+
+// Debug writes the given input to syslog (sev=LOG_DEBUG) if snap `debug`
+// configuration option is set to `true`.
+// It formats similar to fmt.Sprint
+func Debug(a ...interface{}) {
+	if debug {
+		slog.Debug(fmt.Sprint(a...))
+	}
+}
+
+// Debugf writes the given input to syslog (sev=LOG_DEBUG) if snap `debug`
+// configuration option is set to `true`.
+// It formats similar to fmt.Sprintf
+func Debugf(format string, a ...interface{}) {
+	Debug(fmt.Sprintf(format, a...))
+}
+
+// Error writes the given input to syslog (sev=LOG_ERROR).
+// It formats similar to fmt.Sprint
+func Error(a ...interface{}) {
+	msg := fmt.Sprint(a...)
+	slog.Err(msg)
+	// print to stderr as well for snap command error output
+	fmt.Fprint(os.Stderr, msg)
+}
+
+// Errorf writes the given input to syslog (sev=LOG_ERROR).
+// It formats similar to fmt.Sprintf
+func Errorf(format string, a ...interface{}) {
+	Error(fmt.Sprintf(format, a...))
+}
+
+// Info writes the given input to syslog (sev=LOG_INFO).
+// It formats similar to fmt.Sprint
+func Info(a ...interface{}) {
+	slog.Info(fmt.Sprint(a...))
+}
+
+// Infof writes the given input to syslog (sev=LOG_INFO).
+// It formats similar to fmt.Sprintf
+func Infof(format string, a ...interface{}) {
+	Info(fmt.Sprintf(format, a...))
+}
+
+// Warn writes the given input to syslog (sev=LOG_WARNING).
+// It formats similar to fmt.Sprint
+func Warn(a ...interface{}) {
+	slog.Err(fmt.Sprint(a...))
+}
+
+// Warnf writes the given input to syslog (sev=LOG_WARNING).
+// It formats similar to fmt.Sprintf
+func Warnf(format string, a ...interface{}) {
+	Warn(fmt.Sprintf(format, a...))
+}
+
+func init() {
+	// TODO: use snapctl get debug to read this
+	// Depends on https://github.com/canonical/edgex-snap-hooks/pull/26
+	debug = true
+
+	snap := os.Getenv("SNAP")
+	if snap == "" {
+		panic("SNAP environment variable is not set")
+	}
+
+	var err error
+	slog, err = syslog.New(syslog.LOG_INFO, snap+":hook")
+	if err != nil {
+		panic(err)
+	}
+}

--- a/log/log.go
+++ b/log/log.go
@@ -28,7 +28,7 @@ var (
 	slog            *syslog.Writer
 	debug           bool
 	snapInstanceKey string // used as default syslog tag and tag prefix
-	tag             string // syslog tag and staderr prefix
+	tag             string // syslog tag and stderr prefix
 )
 
 func init() {
@@ -57,16 +57,6 @@ func init() {
 	}
 
 	Debugf("debug=%t", debug)
-}
-
-func setupSyslogWriter(tag string) error {
-	writer, err := syslog.New(syslog.LOG_INFO, tag)
-	if err != nil {
-		return err
-	}
-	// switch to new global writer only if no error
-	slog = writer
-	return nil
 }
 
 // SetComponentName adds a component name to syslog tag as "my-snap.<component>"
@@ -104,7 +94,7 @@ func Debugf(format string, a ...interface{}) {
 func Error(a ...interface{}) {
 	msg := fmt.Sprint(a...)
 	slog.Err(msg)
-	// print to stderr as well for snap command error output
+	// print to stderr as well so that snap command prints them on non-zero exit
 	stderr(a...)
 }
 
@@ -144,4 +134,14 @@ func stderr(a ...interface{}) {
 	// Standard errors get collected with "snapd" as syslog app.
 	// We add the tag as prefix to distinguish these from other snapd logs.
 	fmt.Fprintf(os.Stderr, tag+": %s\n", a...)
+}
+
+func setupSyslogWriter(tag string) error {
+	writer, err := syslog.New(syslog.LOG_INFO, tag)
+	if err != nil {
+		return err
+	}
+	// switch to new global writer only if no error
+	slog = writer
+	return nil
 }

--- a/log/log.go
+++ b/log/log.go
@@ -84,7 +84,7 @@ func Infof(format string, a ...interface{}) {
 // Warn writes the given input to syslog (sev=LOG_WARNING).
 // It formats similar to fmt.Sprint
 func Warn(a ...interface{}) {
-	slog.Err(fmt.Sprint(a...))
+	slog.Warning(fmt.Sprint(a...))
 }
 
 // Warnf writes the given input to syslog (sev=LOG_WARNING).

--- a/log/log.go
+++ b/log/log.go
@@ -38,7 +38,7 @@ func init() {
 		snapctl.Unset("debug").Run()
 		value, err := snapctl.Get("debug").Run()
 		if err != nil {
-			Stderr(err)
+			stderr(err)
 			os.Exit(1)
 		}
 		debug = (value == "true")
@@ -46,13 +46,13 @@ func init() {
 
 	snapInstanceKey = os.Getenv("SNAP_INSTANCE_NAME")
 	if snapInstanceKey == "" {
-		Stderr("SNAP_INSTANCE_NAME environment variable not set.")
+		stderr("SNAP_INSTANCE_NAME environment variable not set.")
 		os.Exit(1)
 	}
 	tag = snapInstanceKey
 
 	if err := setupSyslogWriter(tag); err != nil {
-		Stderr(err)
+		stderr(err)
 		os.Exit(1)
 	}
 
@@ -105,7 +105,7 @@ func Error(a ...interface{}) {
 	msg := fmt.Sprint(a...)
 	slog.Err(msg)
 	// print to stderr as well for snap command error output
-	Stderr(a...)
+	stderr(a...)
 }
 
 // Errorf writes the given input to syslog (sev=LOG_ERROR).
@@ -138,15 +138,10 @@ func Warnf(format string, a ...interface{}) {
 	Warn(fmt.Sprintf(format, a...))
 }
 
-// Stderr writes the given input to standard error.
-// It formats similar to fmt.Sprintf, adds the global tag as prefix, and appends
-// a newline
-func Stderr(a ...interface{}) {
+// stderr writes the given input to standard error.
+// It formats similar to fmt.Sprint, adds the global tag as prefix, and appends a newline
+func stderr(a ...interface{}) {
+	// Standard errors get collected with "snapd" as syslog app.
+	// We add the tag as prefix to distinguish these from other snapd logs.
 	fmt.Fprintf(os.Stderr, tag+": %s\n", a...)
-}
-
-// Stderrf writes the given input to standard error.
-// It formats similar to fmt.Sprintf and calls log.Stderr which appends a newline
-func Stderrf(format string, a ...interface{}) {
-	Stderr(fmt.Sprintf(format, a...))
 }

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0'
+ */
+
+package log
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInit(t *testing.T) {
+	t.Run("global instance key", func(t *testing.T) {
+		require.NotEmpty(t, snapInstanceKey)
+	})
+
+	t.Run("global debug variable", func(t *testing.T) {
+		require.False(t, debug)
+	})
+
+	t.Run("global syslog writer", func(t *testing.T) {
+		require.NotNil(t, slog)
+	})
+}
+
+func TestSetComponentName(t *testing.T) {
+	SetComponentName("tester")
+}

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -18,23 +18,7 @@ package log
 
 import (
 	"testing"
-
-	"github.com/stretchr/testify/require"
 )
-
-func TestInit(t *testing.T) {
-	t.Run("global instance key", func(t *testing.T) {
-		require.NotEmpty(t, snapInstanceKey)
-	})
-
-	t.Run("global debug variable", func(t *testing.T) {
-		require.False(t, debug)
-	})
-
-	t.Run("global syslog writer", func(t *testing.T) {
-		require.NotNil(t, slog)
-	})
-}
 
 func TestSetComponentName(t *testing.T) {
 	SetComponentName("tester")

--- a/utils.go
+++ b/utils.go
@@ -171,7 +171,8 @@ func Init(setDebug bool, snapName string) error {
 
 func init() {
 	if err := getEnvVars(); err != nil {
-		log.Stderr(err)
+		log.Error(err)
+		os.Exit(1)
 	}
 }
 


### PR DESCRIPTION
This PR adds a separate logging package with extended functionality.

It:
- fixes #24
- fixes #12
- fixes #29

Test by adding the following to `go.mod`:
```
replace github.com/canonical/edgex-snap-hooks/v2 => github.com/farshidtz/edgex-snap-hooks/v2 da083736dcb18258dd425431d06df0b42e96760c
```

Add to configure hook:
```
log.SetComponentName("configure")
log.Infof("info testing new library")
log.Debugf("debug testing new library")
log.Warnf("warn testing new library")
log.Errorf("err testing new library")
log.Errorf("err testing new library 2")
os.Exit(1)
```

Build and install. Logs should show:
```
$ sudo snap install --dangerous ./edgex-device-mqtt_2.2.0-dev.9_amd64.snap 
error: cannot perform the following tasks:
- Run configure hook of "edgex-device-mqtt" snap if present (run hook "configure": 
-----
edgex-device-mqtt.configure: err testing new library
edgex-device-mqtt.configure: err testing new library 2
-----)
```
```
$ journalctl -f | grep "new library"
Mar 10 10:39:54 farshid-cirrus7 edgex-device-mqtt.configure[59291]: info testing new library
Mar 10 10:39:54 farshid-cirrus7 edgex-device-mqtt.configure[59291]: warn testing new library
Mar 10 10:39:54 farshid-cirrus7 edgex-device-mqtt.configure[59291]: err testing new library
Mar 10 10:39:54 farshid-cirrus7 edgex-device-mqtt.configure[59291]: err testing new library 2
Mar 10 10:39:54 farshid-cirrus7 snapd[1349]: edgex-device-mqtt.configure: err testing new library
Mar 10 10:39:54 farshid-cirrus7 snapd[1349]: edgex-device-mqtt.configure: err testing new library 2

```
