### PR TITLE
Handle mixed env legacy options

### DIFF
--- a/options/options.go
+++ b/options/options.go
@@ -70,7 +70,7 @@ func processGlobalConfigOptions(services []string) error {
 		for env, value := range configuration {
 			overrides.setEnvVariable(env, value)
 		}
-		overrides.writeEnvFile(true)
+		overrides.writeEnvFile(false)
 	}
 	return nil
 }
@@ -132,6 +132,14 @@ func processAppConfigOptions(services []string) error {
 // b) snap set edgex-snap-name config.<my.env.var>
 //	-> sets env variable for all apps (e.g. DEBUG=true, SERVICE_SERVERBINDADDRESS=0.0.0.0)
 func ProcessAppConfig(services ...string) error {
+
+	legacyOptions, err := snapctl.Get("env").Run()
+	if err != nil {
+		return err
+	}
+	if legacyOptions != "" {
+		return fmt.Errorf("Legacy 'env.' options must not be mixed with the new 'config.' and 'app.' options")
+	}
 
 	if len(services) == 0 {
 		return fmt.Errorf("empty service list")

--- a/options/options_test.go
+++ b/options/options_test.go
@@ -126,6 +126,27 @@ func TestProcessAppConfig(t *testing.T) {
 		})
 	})
 
+	t.Run("Set mixed legacy options", func(t *testing.T) {
+		const (
+			legacyKey, legacyValue = "env.security-bootstrapper.add-registry-acl-roles", "legacy1,legacy2"
+			key, value             = "apps.security-bootstrapper.config.add-registry-acl-roles", "legacy1,legacy2"
+		)
+
+		t.Cleanup(func() {
+			//			assert.NoError(t, snapctl.Unset("env").Run())
+			assert.NoError(t, snapctl.Unset(legacyKey).Run())
+			assert.NoError(t, snapctl.Unset(key).Run())
+		})
+		t.Run("set", func(t *testing.T) {
+			require.NoError(t, snapctl.Set(legacyKey, legacyValue).Run())
+			require.NoError(t, options.ProcessAppConfig("security-bootstrapper"))
+			k, err := snapctl.Get(key).Run()
+			require.Equal(t, k, value)
+			require.NoError(t, err)
+
+		})
+	})
+
 	t.Run("reject mixed legacy options", func(t *testing.T) {
 		const (
 			legacyKey, legacyValue = "env.core-data.service.host", "legacy"
@@ -151,6 +172,7 @@ func TestProcessAppConfig(t *testing.T) {
 			require.NoError(t, applyLegacyOptions("core-data"))
 			require.Error(t, options.ProcessAppConfig(testService, "core-data"))
 		})
+
 	})
 
 }


### PR DESCRIPTION
Implement a mapping of env options set in the edgexfoundry install hook to apps.*
Throw an error in other mixed configurations

- Closes #34 by disallowing other mixed options and throwing an error
- Relates to #37