### PR TITLE
Fix rejecting mixed legacy options

### DIFF
--- a/options/options.go
+++ b/options/options.go
@@ -106,13 +106,6 @@ func migrateLegacyOptions() error {
 		}
 	}
 
-	legacyOptions, err := snapctl.Get("env").Run()
-	if err != nil {
-		return err
-	}
-	if legacyOptions != "" && legacyOptions != "{}" {
-		return fmt.Errorf("'config.' and 'app.' options must not be mixed with legacy 'env.' options: %s", legacyOptions)
-	}
 	return nil
 }
 
@@ -175,9 +168,16 @@ func processAppConfigOptions(services []string) error {
 func ProcessAppConfig(services ...string) error {
 
 	err := migrateLegacyOptions()
-
 	if err != nil {
 		return err
+	}
+
+	legacyOptions, err := snapctl.Get("env").Run()
+	if err != nil {
+		return err
+	}
+	if legacyOptions != "" && legacyOptions != "{}" {
+		return fmt.Errorf("'config.' and 'app.' options must not be mixed with legacy 'env.' options: %s", legacyOptions)
 	}
 
 	if len(services) == 0 {

--- a/options/options.go
+++ b/options/options.go
@@ -90,14 +90,20 @@ func migrateLegacyOptions() error {
 			return err
 		}
 		if setting != "" {
-			snapctl.Unset(k).Run()
-			snapctl.Set(v, setting).Run()
+			if err := snapctl.Unset(k).Run(); err != nil {
+				return err
+			}
+			if err := snapctl.Set(v, setting).Run(); err != nil {
+				return err
+			}
 			log.Debugf("Migrated %s to %s", k, v)
 		}
 	}
 
 	for _, s := range clear {
-		snapctl.Unset(s).Run()
+		if err := snapctl.Unset(s).Run(); err != nil {
+			return err
+		}
 	}
 
 	legacyOptions, err := snapctl.Get("env").Run()
@@ -105,7 +111,7 @@ func migrateLegacyOptions() error {
 		return err
 	}
 	if legacyOptions != "" && legacyOptions != "{}" {
-		return fmt.Errorf("legacy 'env.' options must not be mixed with the new 'config.' and 'app.' options")
+		return fmt.Errorf("'config.' and 'app.' options must not be mixed with legacy 'env.' options: %s", legacyOptions)
 	}
 	return nil
 }

--- a/options/options.go
+++ b/options/options.go
@@ -84,6 +84,7 @@ func migrateLegacyOptions() error {
 		"env.security-secret-store.add-known-secrets":      "apps.security-secretstore-setup.config.add-known-secrets",
 		"env.security-bootstrapper.add-registry-acl-roles": "apps.security-bootstrapper.config.add-registry-acl-roles"}
 
+	migrated := false
 	for k, v := range namespaceMap {
 		setting, err := snapctl.Get(k).Run()
 		if err != nil {
@@ -97,12 +98,15 @@ func migrateLegacyOptions() error {
 				return err
 			}
 			log.Debugf("Migrated %s to %s", k, v)
+			migrated = true
 		}
 	}
 
-	for _, s := range clear {
-		if err := snapctl.Unset(s).Run(); err != nil {
-			return err
+	if migrated {
+		for _, s := range clear {
+			if err := snapctl.Unset(s).Run(); err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
Two fixes:
- Reject legacy env options only when apps and config are set
- Unset options only if they have been migrated (this is to avoid having unnecessary dangling `env: {}` config option on unset.