### PR TITLE
Fix options migration, implement proxy options

### DIFF
--- a/log/init.go
+++ b/log/init.go
@@ -13,10 +13,10 @@ var (
 )
 
 func init() {
-	initialize()
+	Init()
 }
 
-func initialize() {
+func Init() {
 	value, err := exec.Command("snapctl", "get", "debug").CombinedOutput()
 	if err != nil {
 		stderr(err)

--- a/log/init_test.go
+++ b/log/init_test.go
@@ -33,13 +33,13 @@ func TestInitialize(t *testing.T) {
 		// set it to true and check
 		output, err := exec.Command("snapctl", "set", "debug=true").CombinedOutput()
 		assert.NoError(t, err, "Error setting config value via snapctl: %s", output)
-		initialize()
+		Init()
 		require.True(t, debug)
 
 		// unset and re-check
 		output, err = exec.Command("snapctl", "unset", "debug").CombinedOutput()
 		assert.NoError(t, err, "Error setting config value via snapctl: %s", output)
-		initialize()
+		Init()
 		require.False(t, debug)
 	})
 

--- a/options/env.go
+++ b/options/env.go
@@ -76,7 +76,7 @@ func (e *envVarOverrides) writeEnvFile(append bool) error {
 	}
 	buf.Write(e.buffer.Bytes())
 
-	log.Infof("Writing settings to %s", e.filename)
+	log.Infof("Writing settings to %s: %s", e.filename, strings.ReplaceAll(e.buffer.String(), "\n", " "))
 
 	tmp := e.filename + ".tmp"
 	err := ioutil.WriteFile(tmp, buf.Bytes(), 0644)

--- a/options/env.go
+++ b/options/env.go
@@ -43,8 +43,10 @@ func getEnvVarFile(service string) *envVarOverrides {
 
 func (e *envVarOverrides) setEnvVariable(setting string, value string) error {
 	result := strings.ToUpper(setting)
-	result = strings.Replace(result, "-", "", -1)
-	result = strings.Replace(result, ".", "_", -1)
+	// replace - with _ for keys such as add-known-secrets and edgex-startup-duration
+	result = strings.ReplaceAll(result, "-", "_")
+	// replace . with _ for config file overrides such as service.port
+	result = strings.ReplaceAll(result, ".", "_")
 	log.Infof("Mapping %s to %s", setting, result)
 	_, err := fmt.Fprintf(e.buffer, "export %s=%s\n", result, value)
 	return err

--- a/options/options.go
+++ b/options/options.go
@@ -228,25 +228,6 @@ func processAppConfigOptions(services []string) error {
 					}
 				}
 			}
-			// config := appConfig["config"]
-			// log.Debugf("Processing config: %v", config)
-			// if config != nil {
-			// 	configuration, err := getConfigMap(config)
-
-			// 	log.Debugf("Processing configuration: %v", configuration)
-			// 	if err != nil {
-			// 		return err
-			// 	}
-			// 	overrides := getEnvVarFile(service)
-
-			// 	log.Debugf("Processing overrides: %v", overrides)
-			// 	for env, value := range configuration {
-
-			// 		log.Debugf("Processing overrides setEnvVariable: %v %v", env, value)
-			// 		overrides.setEnvVariable(env, value)
-			// 	}
-			// 	overrides.writeEnvFile(true)
-			// }
 		}
 	}
 	return nil

--- a/options/options.go
+++ b/options/options.go
@@ -189,16 +189,17 @@ func ProcessAppConfig(services ...string) error {
 		return fmt.Errorf("empty service list")
 	}
 
-	configEnabled, err := snapctl.Get("config-enabled").Run()
+	configEnabledStr, err := snapctl.Get("config-enabled").Run()
 	if err != nil {
 		return err
 	}
+	configEnabled := (configEnabledStr == "true")
 
 	isSet := func(v string) bool {
 		return !(v == "" || v == "{}")
 	}
 
-	if configEnabled != "true" {
+	if !configEnabled {
 		appsOptions, err := snapctl.Get("apps").Run()
 		if err != nil {
 			return err
@@ -217,10 +218,8 @@ Exception: The following legacy 'env.' options are automatically converted:
 	- env.security-secret-store.add-known-secrets
 	- env.security-bootstrapper.add-registry-acl-roles`)
 		} else {
-			// do nothing
 			log.Debug("No config options are set.")
-			// TODO
-			// flush left-over env files
+			// return and continue with legacy option handling.
 			return nil
 		}
 	}

--- a/options/options_test.go
+++ b/options/options_test.go
@@ -27,6 +27,7 @@ import (
 
 	hooks "github.com/canonical/edgex-snap-hooks/v2"
 	"github.com/canonical/edgex-snap-hooks/v2/env"
+	"github.com/canonical/edgex-snap-hooks/v2/log"
 	"github.com/canonical/edgex-snap-hooks/v2/options"
 	"github.com/canonical/edgex-snap-hooks/v2/snapctl"
 	"github.com/stretchr/testify/assert"
@@ -34,8 +35,9 @@ import (
 )
 
 const (
-	testService  = "test-service"
-	testService2 = "test-service2"
+	testService   = "test-service"
+	testService2  = "test-service2"
+	configEnabled = "config-enabled"
 )
 
 func TestProcessAppConfig(t *testing.T) {
@@ -48,8 +50,12 @@ func TestProcessAppConfig(t *testing.T) {
 	envFile2 := path.Join(configDir2, testService2+".env")
 	os.MkdirAll(configDir2, os.ModePerm)
 
+	require.NoError(t, snapctl.Set("debug", "true").Run())
+	log.Init()
+
 	t.Cleanup(func() {
 		assert.NoError(t, snapctl.Unset("apps", "config", "env").Run())
+		assert.NoError(t, snapctl.Unset("debug").Run())
 		assert.NoError(t, os.RemoveAll(configDir))
 		assert.NoError(t, os.RemoveAll(configDir2))
 	})
@@ -68,7 +74,27 @@ func TestProcessAppConfig(t *testing.T) {
 			assert.NoError(t, os.RemoveAll(envFile2))
 		})
 
+		t.Run("reject without enabling", func(t *testing.T) {
+			require.NoError(t, snapctl.Set(key, value).Run())
+
+			require.Error(t, options.ProcessAppConfig(testService, testService2))
+		})
+
 		t.Run("set", func(t *testing.T) {
+			require.NoError(t, snapctl.Set(configEnabled, "true").Run())
+			t.Cleanup(func() {
+				require.NoError(t, snapctl.Unset(configEnabled).Run())
+				require.NoError(t, snapctl.Unset("config").Run())
+
+				require.NoError(t, options.ProcessAppConfig(testService, testService2))
+
+				// it should be removed from both env files
+				require.Error(t, isInFile(envFile, "export X_Y=value"),
+					"File content:\n%s", readFile(envFile))
+				require.Error(t, isInFile(envFile2, "export X_Y=value"),
+					"File content:\n%s", readFile(envFile2))
+			})
+
 			require.NoError(t, snapctl.Set(key, value).Run())
 
 			require.NoError(t, options.ProcessAppConfig(testService, testService2))
@@ -81,15 +107,7 @@ func TestProcessAppConfig(t *testing.T) {
 		})
 
 		t.Run("unset", func(t *testing.T) {
-			require.NoError(t, snapctl.Unset(key, value).Run())
 
-			require.NoError(t, options.ProcessAppConfig(testService, testService2))
-
-			// it should be removed from both env files
-			require.Error(t, isInFile(envFile, "export X_Y=value"),
-				"File content:\n%s", readFile(envFile))
-			require.Error(t, isInFile(envFile2, "export X_Y=value"),
-				"File content:\n%s", readFile(envFile2))
 		})
 	})
 
@@ -102,6 +120,18 @@ func TestProcessAppConfig(t *testing.T) {
 		})
 
 		t.Run("set", func(t *testing.T) {
+			require.NoError(t, snapctl.Set(configEnabled, "true").Run())
+			t.Cleanup(func() {
+				require.NoError(t, snapctl.Unset("apps").Run())
+				require.NoError(t, snapctl.Unset(configEnabled).Run())
+
+				require.NoError(t, options.ProcessAppConfig(testService, testService2))
+
+				// it should be removed from the env file
+				require.Error(t, isInFile(envFile, "export X_Y=value"),
+					"File content:\n%s", readFile(envFile))
+			})
+
 			require.NoError(t, snapctl.Set(key, value).Run())
 
 			require.NoError(t, options.ProcessAppConfig(testService, testService2))
@@ -115,15 +145,15 @@ func TestProcessAppConfig(t *testing.T) {
 				"File content:\n%s", readFile(envFile2))
 		})
 
-		t.Run("unset", func(t *testing.T) {
-			require.NoError(t, snapctl.Unset(key, value).Run())
+		// t.Run("unset", func(t *testing.T) {
+		// 	require.NoError(t, snapctl.Unset(key, value).Run())
 
-			require.NoError(t, options.ProcessAppConfig(testService, testService2))
+		// 	require.NoError(t, options.ProcessAppConfig(testService, testService2))
 
-			// it should be removed from the env file
-			require.Error(t, isInFile(envFile, "export X_Y=value"),
-				"File content:\n%s", readFile(envFile))
-		})
+		// 	// it should be removed from the env file
+		// 	require.Error(t, isInFile(envFile, "export X_Y=value"),
+		// 		"File content:\n%s", readFile(envFile))
+		// })
 	})
 
 	t.Run("Set mixed legacy options", func(t *testing.T) {
@@ -138,6 +168,11 @@ func TestProcessAppConfig(t *testing.T) {
 			assert.NoError(t, snapctl.Unset(key).Run())
 		})
 		t.Run("set", func(t *testing.T) {
+			require.NoError(t, snapctl.Set(configEnabled, "true").Run())
+			t.Cleanup(func() {
+				assert.NoError(t, snapctl.Unset(configEnabled).Run())
+			})
+
 			require.NoError(t, snapctl.Set(legacyKey, legacyValue).Run())
 			require.NoError(t, options.ProcessAppConfig("security-bootstrapper"))
 			k, err := snapctl.Get(key).Run()

--- a/options/secrets-config.go
+++ b/options/secrets-config.go
@@ -123,13 +123,6 @@ func SecurityProxyDeleteCurrentUserIfSet() error {
 	}
 
 	args := []string{"proxy", "deluser", "--user", username, "--jwt", kongAdminToken}
-	// service := "security-proxy-setup"
-	// cmdSecretsConfig := exec.Command("secrets-config", args...)
-	// cmdSecretsConfig.Dir = fmt.Sprintf("%s/%s", env.SnapDataConf, service)
-	// out, err := cmdSecretsConfig.CombinedOutput()
-	// if err != nil {
-	// 	return fmt.Errorf("error executing secrets-config command: %s: %s", err, out)
-	// }
 	err = securityProxyExecSecretsConfig(args)
 	if err != nil {
 		return fmt.Errorf("error executing secrets-config command: %s", err)
@@ -223,9 +216,7 @@ func validateSecretsConfigProxyOptions(proxyMap configOptions, proxyObj proxyOpt
 	// flatten and reject unknown keys
 
 	// const (
-	// 	keyAdmin       = "admin"
 	// 	keyAdminPubKey = "admin.public-key"
-	// 	keyTLS         = "tls"
 	// 	keyTLSCert     = "tls.cert"
 	// 	keyTLSKey      = "tls.key"
 	// 	keyTLSSNIs     = "tls.snis"
@@ -280,35 +271,6 @@ func processSecretsConfigProxyOptions(proxyMap configOptions) error {
 		return fmt.Errorf("error validating secrets-config proxy options: %s", err)
 	}
 
-	// if jwtUsername == "" && jwtPublicKey == "" {
-	// 	// if the values have been set to "" then delete the current user
-	// 	options.SecurityProxyDeleteCurrentUserIfSet()
-	// } else if jwtUsername != "" && jwtPublicKey != "" {
-	// 	// else add a new user
-	// 	err = options.SecurityProxyAddUser(jwtUsername, jwtUserID, jwtAlgorithm, jwtPublicKey)
-	// 	if err != nil {
-	// 		return err
-	// 	}
-	// }
-
-	// // add/delete user
-	// adminPubKeyInt := proxyOptions[keyAdminPubKey]
-	// log.Debugf("Processing secrets-config proxy adminPubKeyInt: %v", adminPubKeyInt)
-	// if adminPubKeyInt != nil {
-	// 	adminPubKey, ok := adminPubKeyInt.(string)
-	// 	if !ok {
-	// 		return fmt.Errorf("%s is not a string: %v", keyUsersAdminPubKey, adminPubKeyInt)
-	// 	}
-
-	// 	if err := SecurityProxyAddUser(defaultUser, defaultId, defaultAlgo, adminPubKey); err != nil {
-	// 		return fmt.Errorf("Error adding user: %s", err)
-	// 	}
-	// } else {
-	// 	if err := SecurityProxyDeleteCurrentUserIfSet(); err != nil {
-	// 		return fmt.Errorf("Error deleting user: %s", err)
-	// 	}
-	// }
-
 	// process the admin user
 	if proxy.Admin.PublicKey != "" {
 		if err := SecurityProxyAddUser(
@@ -323,17 +285,6 @@ func processSecretsConfigProxyOptions(proxyMap configOptions) error {
 			return fmt.Errorf("error deleting user: %s", err)
 		}
 	}
-
-	// if tlsCertificate == "" && tlsPrivateKey == "" {
-	// 	// if the values have been set to "" then clear the semaphore so that a new cert can be set
-	// 	options.SecurityProxyDeleteCurrentTLSCertIfSet()
-	// } else if tlsCertificate != "" && tlsPrivateKey != "" {
-	// 	// Set the TLS certificate and private key
-	// 	err = options.SecurityProxySetTLSCertificate(tlsCertificate, tlsPrivateKey, tlsSNI)
-	// 	if err != nil {
-	// 		return err
-	// 	}
-	// }
 
 	// process TLS certificate
 	if proxy.TLS.Cert != "" && proxy.TLS.Key != "" {

--- a/options/secrets-config.go
+++ b/options/secrets-config.go
@@ -1,0 +1,187 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0'
+ */
+
+package options
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+
+	"github.com/canonical/edgex-snap-hooks/v2/env"
+	"github.com/canonical/edgex-snap-hooks/v2/log"
+)
+
+const (
+	userSemaphoreFile  = ".secrets-config-user"
+	tlsSemaphoreFile   = ".secrets-config-tls"
+	kongAdminTokenFile = "kong-admin-jwt"
+)
+
+// Write a security-proxy file
+func securityProxyWriteFile(filename, contents string) (path string, err error) {
+	path = fmt.Sprintf("%s/secrets/security-proxy-setup/%s", env.SnapData, filename)
+	err = ioutil.WriteFile(path, []byte(contents), 0600)
+	if err == nil {
+		log.Debugf("Wrote file '%s'", path)
+	} else {
+		err = fmt.Errorf("failed to write file %s - %v", path, err)
+	}
+	return
+}
+
+// Read a security-proxy file
+func securityProxyReadFile(filename string) (contents string, err error) {
+	path := fmt.Sprintf("%s/secrets/security-proxy-setup/%s", env.SnapData, filename)
+	bytes, err := ioutil.ReadFile(path)
+	if err == nil {
+		contents = string(bytes)
+		log.Debugf("Read file '%s'", path)
+	} else {
+		err = fmt.Errorf("failed to read file %s - %v", path, err)
+	}
+	return
+}
+
+// Delete a security-proxy semaphore file
+func securityProxyRemoveSemaphore(filename string) (err error) {
+	path := fmt.Sprintf("%s/secrets/security-proxy-setup/%s", env.SnapData, filename)
+	err = os.Remove(path)
+	if err == nil {
+		log.Debug("Removed file '" + path + "'")
+	} else {
+		log.Debugf("Could not remove file '%s' : %v", path, err)
+	}
+	return
+}
+
+// Execute the secrets-config tool with the given arguments
+func securityProxyExecSecretsConfig(args []string) error {
+	service := "security-proxy-setup"
+	cmdSecretsConfig := exec.Command("secrets-config", args...)
+	cmdSecretsConfig.Dir = fmt.Sprintf("%s/%s", env.SnapDataConf, service)
+	out, err := cmdSecretsConfig.Output()
+	log.Debug("Executed \"secrets-config " + fmt.Sprint(args) + "\" result=" + string(out))
+	return err
+}
+
+// Remove the semaphore, so that we can set the certificate again
+func SecurityProxyDeleteCurrentTLSCertIfSet() error {
+
+	return securityProxyRemoveSemaphore(tlsSemaphoreFile)
+}
+
+// Delete the current user - if one has been set up
+func SecurityProxyDeleteCurrentUserIfSet() error {
+	service := "security-proxy-setup"
+	// if no user has been set up, then ignore the request
+	username, err := securityProxyReadFile(userSemaphoreFile)
+	if err != nil {
+		log.Debug("proxy: No user has been set up")
+		return nil
+	}
+
+	args := []string{"proxy", "deluser", "--user", username}
+	cmdSecretsConfig := exec.Command("secrets-config", args...)
+	cmdSecretsConfig.Dir = fmt.Sprintf("%s/%s", env.SnapDataConf, service)
+	out, err := cmdSecretsConfig.Output()
+	if err != nil {
+		return err
+	}
+
+	securityProxyRemoveSemaphore(userSemaphoreFile)
+	log.Debug("Executed \"secrets-config " + fmt.Sprint(args) + "\" result=" + string(out))
+	log.Info("proxy: Removed current user")
+	return nil
+}
+
+// Set up the proxy with the specified user.
+func SecurityProxyAddUser(jwtUsername, jwtUserID, jwtAlgorithm, jwtPublicKey string) error {
+	currentUser, err := securityProxyReadFile(userSemaphoreFile)
+	if err == nil && currentUser != "" {
+		if currentUser == jwtUsername {
+			//	If a user has already been set - and it's the same user - then silently ignore the request
+			log.Debug("proxy: Ignoring request to set up same user again")
+			return nil
+		} else {
+			// if this is a different user, then return an error
+			return fmt.Errorf("the proxy user has already been set. To add a new user, first delete the current user by setting 'user' and 'public-key' to an empy string")
+		}
+	}
+
+	publicKeyFilePath, err := securityProxyWriteFile("jwt-user-public-key.pem", jwtPublicKey)
+	if err != nil {
+		return err
+	}
+
+	kongAdminToken, err := securityProxyReadFile(kongAdminTokenFile)
+	if err != nil {
+		return err
+	}
+
+	args := []string{"proxy", "adduser", "--token-type", "jwt", "--user", jwtUsername, "--id", jwtUserID, "--algorithm", jwtAlgorithm, "--public_key", publicKeyFilePath, "--jwt", kongAdminToken}
+	err = securityProxyExecSecretsConfig(args)
+	if err != nil {
+		return fmt.Errorf("failed to create proxy user - %v", err)
+	}
+	_, err = securityProxyWriteFile(userSemaphoreFile, jwtUsername)
+	if err != nil {
+		return err
+	}
+	log.Info("proxy: Added new user")
+	return nil
+}
+
+// Set the TLS certificate. If a certificate has already been set then silently ignore the request
+func SecurityProxySetTLSCertificate(tlsCertificate, tlsPrivateKey, tlsSNI string) error {
+	_, err := securityProxyReadFile(tlsSemaphoreFile)
+	if err == nil {
+		log.Debug("The TLS certificate has already been set. To set it again, first set tls-certificate and tls-private-key to an empty string")
+		return nil
+	}
+	tlsCertFilename, err := securityProxyWriteFile("tls-certificate.pem", tlsCertificate)
+	if err != nil {
+		return err
+	}
+	tlsPrivateKeyFilename, err := securityProxyWriteFile("tls-private-key.pem", tlsPrivateKey)
+	if err != nil {
+		return err
+	}
+
+	kongAdminToken, err := securityProxyReadFile(kongAdminTokenFile)
+	if err != nil {
+		return err
+	}
+
+	args := []string{"proxy", "tls", "--incert", tlsCertFilename, "--inkey", tlsPrivateKeyFilename, "--admin_api_jwt", kongAdminToken}
+	if tlsSNI != "" {
+		args = append(args, "--snis", tlsSNI)
+	}
+	err = securityProxyExecSecretsConfig(args)
+
+	if err != nil {
+		return fmt.Errorf("failed to set TLS certificate - %v", err)
+	}
+	_, err = securityProxyWriteFile(tlsSemaphoreFile, "TLS certificate set")
+	if err != nil {
+		return err
+	}
+	log.Info("New TLS Certificate and private key set")
+	return nil
+}

--- a/options/secrets-config.go
+++ b/options/secrets-config.go
@@ -103,13 +103,23 @@ func securityProxyExecSecretsConfig(args []string) error {
 	return nil
 }
 
-// Remove the semaphore, so that we can set the certificate again
+// Deprecated
 func SecurityProxyDeleteCurrentTLSCertIfSet() error {
+	return securityProxyDeleteCurrentTLSCertIfSet()
+}
+
+// Remove the semaphore, so that we can set the certificate again
+func securityProxyDeleteCurrentTLSCertIfSet() error {
 	return securityProxyRemoveSemaphore(tlsSemaphoreFile)
 }
 
-// Delete the current user - if one has been set up
+// Deprecated
 func SecurityProxyDeleteCurrentUserIfSet() error {
+	return securityProxyDeleteCurrentUserIfSet()
+}
+
+// Delete the current user - if one has been set up
+func securityProxyDeleteCurrentUserIfSet() error {
 	// if no user has been set up, then ignore the request
 	username, err := securityProxyReadFile(userSemaphoreFile)
 	if err != nil {
@@ -134,8 +144,13 @@ func SecurityProxyDeleteCurrentUserIfSet() error {
 	return nil
 }
 
-// Set up the proxy with the specified user.
+// Deprecated
 func SecurityProxyAddUser(jwtUsername, jwtUserID, jwtAlgorithm, jwtPublicKey string) error {
+	return securityProxyAddUser(jwtUsername, jwtUserID, jwtAlgorithm, jwtPublicKey)
+}
+
+// Set up the proxy with the specified user.
+func securityProxyAddUser(jwtUsername, jwtUserID, jwtAlgorithm, jwtPublicKey string) error {
 	currentUser, err := securityProxyReadFile(userSemaphoreFile)
 	if err == nil && currentUser != "" {
 		if currentUser == jwtUsername {
@@ -171,8 +186,13 @@ func SecurityProxyAddUser(jwtUsername, jwtUserID, jwtAlgorithm, jwtPublicKey str
 	return nil
 }
 
-// Set the TLS certificate. If a certificate has already been set then silently ignore the request
+// Deprecated
 func SecurityProxySetTLSCertificate(tlsCertificate, tlsPrivateKey, tlsSNIs string) error {
+	return securityProxySetTLSCertificate(tlsCertificate, tlsPrivateKey, tlsSNIs)
+}
+
+// Set the TLS certificate. If a certificate has already been set then silently ignore the request
+func securityProxySetTLSCertificate(tlsCertificate, tlsPrivateKey, tlsSNIs string) error {
 	_, err := securityProxyReadFile(tlsSemaphoreFile)
 	if err == nil {
 		log.Debug("The TLS certificate has already been set. To set it again, first set tls-certificate and tls-private-key to an empty string")

--- a/utils.go
+++ b/utils.go
@@ -32,6 +32,7 @@ import (
 	"strings"
 
 	"github.com/canonical/edgex-snap-hooks/v2/log"
+	"github.com/canonical/edgex-snap-hooks/v2/options"
 )
 
 var (
@@ -370,162 +371,6 @@ func flattenConfigJSON(p string, k string, vJSON interface{}, flatConf map[strin
 	}
 }
 
-const userSemaphoreFile = ".secrets-config-user"
-const tlsSemaphoreFile = ".secrets-config-tls"
-const kongAdminTokenFile = "kong-admin-jwt"
-
-// Write a security-proxy file
-func securityProxyWriteFile(filename, contents string) (path string, err error) {
-	path = fmt.Sprintf("%s/secrets/security-proxy-setup/%s", SnapData, filename)
-	err = ioutil.WriteFile(path, []byte(contents), 0600)
-	if err == nil {
-		Debug(fmt.Sprintf("Wrote file '%s'", path))
-	} else {
-		err = fmt.Errorf("failed to write file %s - %v", path, err)
-	}
-	return
-}
-
-// Read a security-proxy file
-func securityProxyReadFile(filename string) (contents string, err error) {
-	path := fmt.Sprintf("%s/secrets/security-proxy-setup/%s", SnapData, filename)
-	bytes, err := ioutil.ReadFile(path)
-	if err == nil {
-		contents = string(bytes)
-		Debug(fmt.Sprintf("Read file '%s'", path))
-	} else {
-		err = fmt.Errorf("failed to read file %s - %v", path, err)
-	}
-	return
-}
-
-// Delete a security-proxy semaphore file
-func securityProxyRemoveSemaphore(filename string) (err error) {
-	path := fmt.Sprintf("%s/secrets/security-proxy-setup/%s", SnapData, filename)
-	err = os.Remove(path)
-	if err == nil {
-		Debug("Removed file '" + path + "'")
-	} else {
-		Debug(fmt.Sprintf("Could not remove file '%s' : %v", path, err))
-	}
-	return
-}
-
-// Execute the secrets-config tool with the given arguments
-func securityProxyExecSecretsConfig(args []string) error {
-	service := "security-proxy-setup"
-	cmdSecretsConfig := exec.Command("secrets-config", args...)
-	cmdSecretsConfig.Dir = fmt.Sprintf("%s/%s", SnapDataConf, service)
-	out, err := cmdSecretsConfig.Output()
-	Debug("Executed \"secrets-config " + fmt.Sprint(args) + "\" result=" + string(out))
-	return err
-}
-
-// Remove the semaphore, so that we can set the certificate again
-func securityProxyDeleteCurrentTLSCertIfSet() error {
-
-	return securityProxyRemoveSemaphore(tlsSemaphoreFile)
-}
-
-// Delete the current user - if one has been set up
-func securityProxyDeleteCurrentUserIfSet() error {
-	service := "security-proxy-setup"
-	// if no user has been set up, then ignore the request
-	username, err := securityProxyReadFile(userSemaphoreFile)
-	if err != nil {
-		Debug("proxy: No user has been set up")
-		return nil
-	}
-
-	args := []string{"proxy", "deluser", "--user", username}
-	cmdSecretsConfig := exec.Command("secrets-config", args...)
-	cmdSecretsConfig.Dir = fmt.Sprintf("%s/%s", SnapDataConf, service)
-	out, err := cmdSecretsConfig.Output()
-	if err != nil {
-		return err
-	}
-
-	securityProxyRemoveSemaphore(userSemaphoreFile)
-	Debug("Executed \"secrets-config " + fmt.Sprint(args) + "\" result=" + string(out))
-	Info("proxy: Removed current user")
-	return nil
-}
-
-// Set up the proxy with the specified user.
-func securityProxyAddUser(jwtUsername, jwtUserID, jwtAlgorithm, jwtPublicKey string) error {
-	currentUser, err := securityProxyReadFile(userSemaphoreFile)
-	if err == nil && currentUser != "" {
-		if currentUser == jwtUsername {
-			//	If a user has already been set - and it's the same user - then silently ignore the request
-			Debug("proxy: Ignoring request to set up same user again")
-			return nil
-		} else {
-			// if this is a different user, then return an error
-			return fmt.Errorf("the proxy user has already been set. To add a new user, first delete the current user by setting 'user' and 'public-key' to an empy string")
-		}
-	}
-
-	publicKeyFilePath, err := securityProxyWriteFile("jwt-user-public-key.pem", jwtPublicKey)
-	if err != nil {
-		return err
-	}
-
-	kongAdminToken, err := securityProxyReadFile(kongAdminTokenFile)
-	if err != nil {
-		return err
-	}
-
-	args := []string{"proxy", "adduser", "--token-type", "jwt", "--user", jwtUsername, "--id", jwtUserID, "--algorithm", jwtAlgorithm, "--public_key", publicKeyFilePath, "--jwt", kongAdminToken}
-	err = securityProxyExecSecretsConfig(args)
-	if err != nil {
-		return fmt.Errorf("failed to create proxy user - %v", err)
-	}
-	_, err = securityProxyWriteFile(userSemaphoreFile, jwtUsername)
-	if err != nil {
-		return err
-	}
-	Info("proxy: Added new user")
-	return nil
-}
-
-// Set the TLS certificate. If a certificate has already been set then silently ignore the request
-func securityProxySetTLSCertificate(tlsCertificate, tlsPrivateKey, tlsSNI string) error {
-	_, err := securityProxyReadFile(tlsSemaphoreFile)
-	if err == nil {
-		Debug("The TLS certificate has already been set. To set it again, first set tls-certificate and tls-private-key to an empty string")
-		return nil
-	}
-	tlsCertFilename, err := securityProxyWriteFile("tls-certificate.pem", tlsCertificate)
-	if err != nil {
-		return err
-	}
-	tlsPrivateKeyFilename, err := securityProxyWriteFile("tls-private-key.pem", tlsPrivateKey)
-	if err != nil {
-		return err
-	}
-
-	kongAdminToken, err := securityProxyReadFile(kongAdminTokenFile)
-	if err != nil {
-		return err
-	}
-
-	args := []string{"proxy", "tls", "--incert", tlsCertFilename, "--inkey", tlsPrivateKeyFilename, "--admin_api_jwt", kongAdminToken}
-	if tlsSNI != "" {
-		args = append(args, "--snis", tlsSNI)
-	}
-	err = securityProxyExecSecretsConfig(args)
-
-	if err != nil {
-		return fmt.Errorf("failed to set TLS certificate - %v", err)
-	}
-	_, err = securityProxyWriteFile(tlsSemaphoreFile, "TLS certificate set")
-	if err != nil {
-		return err
-	}
-	Info("New TLS Certificate and private key set")
-	return nil
-}
-
 // This func checks the given key for a service-specific prefix
 // delimited by a '/'. The prefix can either be a service name or a
 // CSV service list. If found, the prefix is compared against
@@ -686,10 +531,10 @@ func HandleEdgeXConfig(service, envJSON string, extraConf map[string]string) err
 		if service == "security-proxy" {
 			if jwtUsername == "" && jwtPublicKey == "" {
 				// if the values have been set to "" then delete the current user
-				securityProxyDeleteCurrentUserIfSet()
+				options.SecurityProxyDeleteCurrentUserIfSet()
 			} else if jwtUsername != "" && jwtPublicKey != "" {
 				// else add a new user
-				err = securityProxyAddUser(jwtUsername, jwtUserID, jwtAlgorithm, jwtPublicKey)
+				err = options.SecurityProxyAddUser(jwtUsername, jwtUserID, jwtAlgorithm, jwtPublicKey)
 				if err != nil {
 					return err
 				}
@@ -697,10 +542,10 @@ func HandleEdgeXConfig(service, envJSON string, extraConf map[string]string) err
 
 			if tlsCertificate == "" && tlsPrivateKey == "" {
 				// if the values have been set to "" then clear the semaphore so that a new cert can be set
-				securityProxyDeleteCurrentTLSCertIfSet()
+				options.SecurityProxyDeleteCurrentTLSCertIfSet()
 			} else if tlsCertificate != "" && tlsPrivateKey != "" {
 				// Set the TLS certificate and private key
-				err = securityProxySetTLSCertificate(tlsCertificate, tlsPrivateKey, tlsSNI)
+				err = options.SecurityProxySetTLSCertificate(tlsCertificate, tlsPrivateKey, tlsSNI)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
Fixes for #38.

Moved proxy-related code to the options package.

Added proxy options processing for TLS:
- apps.secrets-config.proxy.tls.cert
- apps.secrets-config.proxy.tls.key
- apps.secrets-config.proxy.tls.snis

Added proxy options processing for user:
- apps.secrets-config.proxy.admin.public-key

For usability purposes, the username, userid, algorithm of the single user have been hardcoded to admin, 1, ES256. This should be sufficient since we don't allow setting multiple users using snap options. The algorithm is set to ES256 rather than RS256, because it is more secure.

To avoid mixed option issues, the new namespace is now enabled after opting-in by setting `config-enabled=true`.

## Testing instructions
Add the following to go.mod:
```
replace github.com/canonical/edgex-snap-hooks/v2 => github.com/farshidtz/edgex-snap-hooks/v2 d43ccc771100d663099c8ca8e3974d78076b2058
```