### PR TITLE
Limit config validation to config options

### DIFF
--- a/options/options.go
+++ b/options/options.go
@@ -157,13 +157,16 @@ func validateAppConfigOptions(configOptions map[string]map[string]configOptions,
 		expected[s] = true
 	}
 
-	for setService := range configOptions {
-		if !expected[setService] {
+	for setService, value := range configOptions {
+		_, isConfig := value["config"]
+
+		if isConfig && !expected[setService] {
 			return fmt.Errorf("unsupported service in app config option: %s. Supported services are: %v",
 				setService,
 				expectedServices,
 			)
 		}
+
 	}
 	return nil
 }


### PR DESCRIPTION
This change is to limit config validation to config options `apps.<app>.config.<var>`, and exclude other options such as `apps.secrets-config.proxy.<var>`.