### PR TITLE
Capture output errors from secrets-config

### DIFF
--- a/options/secrets-config.go
+++ b/options/secrets-config.go
@@ -96,6 +96,11 @@ func securityProxyExecSecretsConfig(args []string) error {
 		return fmt.Errorf("error executing 'secrets-config %s': error=%s: output=%s",
 			strings.Join(args, " "), err, out)
 	}
+	// secrets-config doesn't always return a non-zero exit code on errors
+	if strings.Contains(string(out), "ERROR") {
+		return fmt.Errorf("error output from 'secrets-config %s': %s",
+			strings.Join(args, " "), out)
+	}
 	log.Debugf("Executed 'secrets-config %s': output=%s", strings.Join(args, " "), out)
 	return nil
 }


### PR DESCRIPTION
This is a temporary workaround for the issue reported at https://github.com/edgexfoundry/edgex-go/issues/4337

### Reproduce
```
# Removed the semaphore file
sudo rm -f /var/snap/edgexfoundry/current/secrets/security-proxy-setup/.secrets-config-user

# Turn the Kong's admin key to something invalid
echo "123" | sudo tee /var/snap/edgexfoundry/current/secrets/security-proxy-setup/kong-admin-jwt

# Set a public key (doesn't need to be valid)
snap set edgexfoundry apps.secrets-config.proxy.admin.public-key="xxx"
# no errors
```

The snap logs:
```
2023-02-27T12:44:30+01:00 systemd[1]: Starting Service for snap application edgexfoundry.secrets-config-processor...
2023-02-27T12:44:30+01:00 edgexfoundry.options[37756]: Processing snap options for secrets-config
2023-02-27T12:44:30+01:00 edgexfoundry.options[37756]: proxy: Added new user
2023-02-27T12:44:30+01:00 systemd[1]: snap.edgexfoundry.secrets-config-processor.service: Deactivated successfully.
2023-02-27T12:44:30+01:00 systemd[1]: Finished Service for snap application edgexfoundry.secrets-config-processor.
```

### After the fix
```
$ snap set edgexfoundry apps.secrets-config.proxy.admin.public-key="xxx"
error: cannot perform the following tasks:
- Run service command "start" for services ["secrets-config-processor"] of snap "edgexfoundry" (systemctl command [start snap.edgexfoundry.secrets-config-processor.service] failed with exit status 1: Job for snap.edgexfoundry.secrets-config-processor.service failed because the control process exited with error code.
See "systemctl status snap.edgexfoundry.secrets-config-processor.service" and "journalctl -xeu snap.edgexfoundry.secrets-config-processor.service" for details.
)
```



Logs:
```
2023-02-27T13:11:20+01:00 systemd[1]: Starting Service for snap application edgexfoundry.secrets-config-processor...
2023-02-27T13:11:20+01:00 edgexfoundry.options[85769]: Processing snap options for secrets-config
2023-02-27T13:11:20+01:00 edgexfoundry.options[85769]: Could not process custom options: error adding user: error executing secrets-config command: error output from 'secrets-config proxy adduser --token-type jwt --user admin --id 1 --algorithm ES256 --public_key /var/snap/edgexfoundry/x1/secrets/security-proxy-setup/jwt-user-public-key.pem --jwt 123
': level=ERROR ts=2023-02-27T12:11:20.67002396Z app=secrets-config source=bootstraphandler.go:77 msg="Failed to send new consumer request admin: Post \"https://127.0.0.1:8443/admin/consumers\": net/http: invalid header field value \"Bearer 123\\n\" for key Authorization"
2023-02-27T13:11:20+01:00 edgexfoundry.secrets-config-processor[85769]: edgexfoundry.options: Could not process custom options: error adding user: error executing secrets-config command: error output from 'secrets-config proxy adduser --token-type jwt --user admin --id 1 --algorithm ES256 --public_key /var/snap/edgexfoundry/x1/secrets/security-proxy-setup/jwt-user-public-key.pem --jwt 123
2023-02-27T13:11:20+01:00 edgexfoundry.secrets-config-processor[85769]: ': level=ERROR ts=2023-02-27T12:11:20.67002396Z app=secrets-config source=bootstraphandler.go:77 msg="Failed to send new consumer request admin: Post \"https://127.0.0.1:8443/admin/consumers\": net/http: invalid header field value \"Bearer 123\\n\" for key Authorization"
2023-02-27T13:11:20+01:00 systemd[1]: snap.edgexfoundry.secrets-config-processor.service: Main process exited, code=exited, status=1/FAILURE
2023-02-27T13:11:20+01:00 systemd[1]: snap.edgexfoundry.secrets-config-processor.service: Failed with result 'exit-code'.
2023-02-27T13:11:20+01:00 systemd[1]: Failed to start Service for snap application edgexfoundry.secrets-config-processor.

```