### PR TITLE
Move env file to parent directory to avoid conflict with config provider

### DIFF
--- a/options/env.go
+++ b/options/env.go
@@ -100,7 +100,7 @@ func (cp *configProcessor) writeEnvFiles() error {
 		}
 
 		// Add comment on top of the file
-		if _, err := fmt.Fprintln(&buffer, "# System-generated list of environment variables from snap options"); err != nil {
+		if _, err := fmt.Fprintln(&buffer, "# Sys-gen env vars from snap options:"); err != nil {
 			return err
 		}
 

--- a/options/env.go
+++ b/options/env.go
@@ -78,9 +78,9 @@ func (cp *configProcessor) filename(service string) string {
 	// include the service name in it's configuration path.
 	var path string
 	if env.SnapName == "edgex-app-service-configurable" {
-		path = fmt.Sprintf("%s/config/res/%s.env", env.SnapData, service)
+		path = fmt.Sprintf("%s/config/overrides.env", env.SnapData)
 	} else {
-		path = fmt.Sprintf("%s/config/%s/res/%s.env", env.SnapData, service, service)
+		path = fmt.Sprintf("%s/config/%s/overrides.env", env.SnapData, service)
 	}
 	return path
 }
@@ -97,6 +97,11 @@ func (cp *configProcessor) writeEnvFiles() error {
 				return fmt.Errorf("failed to remove env file: %s", err)
 			}
 			continue
+		}
+
+		// Add comment on top of the file
+		if _, err := fmt.Fprintln(&buffer, "# System-generated list of environment variables from snap options"); err != nil {
+			return err
 		}
 
 		// add env vars to buffer

--- a/options/options_test.go
+++ b/options/options_test.go
@@ -42,12 +42,12 @@ func TestProcessConfig(t *testing.T) {
 	// uncomment to cleanup previous mess
 	// assert.NoError(t, snapctl.Unset("app-options", "config-enabled", "apps", "config").Run())
 
-	configDir := fmt.Sprintf("%s/config/%s/res/", env.SnapData, testService)
-	envFile := path.Join(configDir, testService+".env")
+	configDir := fmt.Sprintf("%s/config/%s/", env.SnapData, testService)
+	envFile := path.Join(configDir, "overrides.env")
 	os.MkdirAll(configDir, os.ModePerm)
 
-	configDir2 := fmt.Sprintf("%s/config/%s/res/", env.SnapData, testService2)
-	envFile2 := path.Join(configDir2, testService2+".env")
+	configDir2 := fmt.Sprintf("%s/config/%s/", env.SnapData, testService2)
+	envFile2 := path.Join(configDir2, "overrides.env")
 	os.MkdirAll(configDir2, os.ModePerm)
 
 	require.NoError(t, snapctl.Set("debug", "true").Run())


### PR DESCRIPTION
## Testing instructions
### Reproduce the error

Install device virtual (edge) and connect the config provider. 
Set a snap option (example: `snap set edgex-device-virtual config.writable-loglevel=DEBUG`)
Look for expected error: `could not process config options: failed to remove env file: unlinkat /var/snap/edgex-device-mqtt/2762/config/device-mqtt/res/device-virtual.env: read-only file system`

### Test
Build from https://github.com/edgexfoundry/device-virtual-go/pull/354
Connect the config provider.

Use:
```
$ snap set edgex-device-virtual config.writable-loglevel=DEBUG
$ cat /var/snap/edgex-device-virtual/current/config/device-virtual/overrides.env 
# System-generated list of environment variables from snap options
WRITABLE_LOGLEVEL="DEBUG"
```